### PR TITLE
ultiple improvements

### DIFF
--- a/src/tox_ini_fmt/__main__.py
+++ b/src/tox_ini_fmt/__main__.py
@@ -1,4 +1,6 @@
+import difflib
 import sys
+from pathlib import Path
 from typing import Optional, Sequence
 
 from tox_ini_fmt.cli import cli_args
@@ -8,12 +10,27 @@ from tox_ini_fmt.formatter import format_tox_ini
 def run(args: Optional[Sequence[str]] = None) -> int:
     opts = cli_args(sys.argv[1:] if args is None else args)
     formatted = format_tox_ini(opts.tox_ini)
-    if opts.stdout:
+    before = opts.tox_ini.read_text()
+    changed = before != formatted
+    if opts.stdout:  # stdout just prints new format to stdout
         print(formatted, end="")
     else:
         opts.tox_ini.write_text(formatted)
-        print(f"updated {opts.tox_ini}")
-    return 0
+        try:
+            name = str(opts.tox_ini.relative_to(Path.cwd()))
+        except ValueError:
+            name = str(opts.tox_ini)
+        diff = (
+            difflib.unified_diff(before.splitlines(), formatted.splitlines(), fromfile=name, tofile=name)
+            if changed
+            else []
+        )
+        if diff:
+            print("\n".join(diff))  # print diff on change
+        else:
+            print(f"no change for {name}")
+    # exit with non success on change
+    return 1 if changed else 0
 
 
 if __name__ == "__main__":

--- a/src/tox_ini_fmt/formatter/util.py
+++ b/src/tox_ini_fmt/formatter/util.py
@@ -6,10 +6,6 @@ def to_boolean(payload: str) -> str:
     return "true" if payload.lower() == "true" else "false"
 
 
-def to_multiline(payload: str) -> str:
-    return "\n{}".format("\n".join(v.strip() for v in payload.splitlines() if v.strip()))
-
-
 def fix_and_reorder(parser: ConfigParser, name: str, fix_cfg: Mapping[str, Callable[[str], str]]) -> None:
     section = parser[name]
     for key, fix in fix_cfg.items():

--- a/tests/formatter/test_test_env.py
+++ b/tests/formatter/test_test_env.py
@@ -15,9 +15,13 @@ def test_no_tox_section(tox_ini):
 def test_format_test_env(tox_ini, section):
     content = dedent(
         """
+    usedevelop = True
     skip_install =\tFalse
+    parallel_show_output = false
     commands = \te
-      \tf
+      \tf  \\
+      \t \\
+      \t g
     extras = \tc,d
     description = \tdesc\t
     deps = \tb\t
@@ -46,15 +50,18 @@ def test_format_test_env(tox_ini, section):
           E = F
         basepython = python3.8
         skip_install = false
+        usedevelop = true
         deps =
           a
           b
         extras =
           c
           d
+        parallel_show_output = false
         commands =
           e
-          f
+          f \\
+            g
         """
     ).lstrip()
     assert outcome == expected

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,23 +4,38 @@ from tox_ini_fmt.__main__ import run
 
 
 @pytest.mark.parametrize("in_place", [True, False])
-def test_main(tmp_path, capsys, in_place):
-    start_text = "[tox]\nenvlist=py39,py38"
+@pytest.mark.parametrize("cwd", [True, False])
+@pytest.mark.parametrize(
+    "start, outcome, output",
+    [
+        (
+            "[tox]\nenvlist=py39,py38",
+            "[tox]\nenvlist =\n  py39\n  py38\n",
+            "--- {0}\n\n+++ {0}\n\n@@ -1,2 +1,4 @@\n\n " "[tox]\n-envlist=py39,py38\n+envlist =\n+  py39\n+  py38\n",
+        ),
+        ("[tox]\nenvlist =\n  py39\n  py38\n", "[tox]\nenvlist =\n  py39\n  py38\n", "no change for {0}\n"),
+    ],
+)
+def test_main(tmp_path, capsys, in_place, start, outcome, output, monkeypatch, cwd):
+    if cwd:
+        monkeypatch.chdir(tmp_path)
     tox_ini = tmp_path / "tox.ini"
-    tox_ini.write_text(start_text)
+    tox_ini.write_text(start)
     args = [str(tox_ini)]
     if not in_place:
         args.append("--stdout")
 
     result = run(args)
-    assert result == 0
+    assert result == (0 if start == outcome else 1)
 
     outcome = "[tox]\nenvlist =\n  py39\n  py38\n"
     out, err = capsys.readouterr()
     assert not err
 
     if in_place:
+        name = "tox.ini" if cwd else str(tmp_path / "tox.ini")
+        output = output.format(name)
         assert tox_ini.read_text() == outcome
-        assert f"updated {tox_ini}" in out
+        assert out == output
     else:
         assert out == outcome


### PR DESCRIPTION
- exit with code 1 on change to the tox.ini, 0 otherwise
- print the unified diff on in-place mode and changed files
- indent splitted multi-line commands by one (remove empty ' \' lines)
- handle usedevelop and parallel_show_output