### PR TITLE
Skip empty requirement lines.

### DIFF
--- a/src/tox_ini_fmt/formatter/requires.py
+++ b/src/tox_ini_fmt/formatter/requires.py
@@ -38,5 +38,5 @@ def _normalize_lib(lib: str) -> str:
 def _req_base(lib: str) -> str:
     match = re.match(BASE_NAME_REGEX, lib)
     if match is None:
-        raise ValueError(lib)
+        raise ValueError(repr(lib))
     return match.group(0)

--- a/src/tox_ini_fmt/formatter/requires.py
+++ b/src/tox_ini_fmt/formatter/requires.py
@@ -9,7 +9,7 @@ def requires(raw: str) -> List[str]:
     require_group = raw.strip().splitlines()
     if not require_group:
         return []
-    values = (_normalize_req(req) for req in require_group)
+    values = (_normalize_req(req) for req in require_group if req)
     normalized = sorted(values, key=lambda req: (";" in req, _req_base(req), req))
     return normalized
 

--- a/tests/formatter/test_requires.py
+++ b/tests/formatter/test_requires.py
@@ -12,6 +12,7 @@ from tox_ini_fmt.formatter.requires import requires
         ("b\na\n", ["a", "b"]),
         ("a\nb\n", ["a", "b"]),
         ("A\na\n", ["A", "a"]),
+        ("\nA\n\n\nb\n\n", ["A", "b"]),
         (
             'packaging>=20.0;python_version>"3.4"\n'
             "xonsh>=0.9.16;python_version > '3.4' and python_version != '3.9'\n"


### PR DESCRIPTION
Closes: #17.

This simply skips such lines to solve #17 immediately.

Personally though longer term, I'd like it if `tox-ini-fmt` actually preserved + used the newlines -- usually I use empty lines there to denote requirements "blocks"/groups. So e.g. if I'm using factor groups I'll put empty lines between the factor groups if they have a bunch of different requirements. Let me know if you agree/disagree with that.