### PR TITLE
Do not strip `.0` version for `compatible releases`

### DIFF
--- a/src/tox_ini_fmt/formatter/requires.py
+++ b/src/tox_ini_fmt/formatter/requires.py
@@ -1,7 +1,7 @@
 import re
 from typing import List
 
-BASE_NAME_REGEX = re.compile(r"[^!=><\s@]+")
+BASE_NAME_REGEX = re.compile(r"[^!=><~\s@]+")
 REQ_REGEX = re.compile(r"(===|==|!=|~=|>=?|<=?|@)\s*([^,]+)")
 
 
@@ -30,7 +30,7 @@ def _normalize_lib(lib: str) -> str:
         key=lambda c: ("<" in c, ">" in "c", c),
     )
     if values:  # strip .0 version
-        while values[0].endswith(".0"):
+        while values[0].endswith(".0") and (values[0].startswith(">=") or values[0].startswith("==")):
             values[0] = values[0][:-2]
     return f"{base}{','.join(values)}"
 

--- a/tests/formatter/test_requires.py
+++ b/tests/formatter/test_requires.py
@@ -23,6 +23,9 @@ from tox_ini_fmt.formatter.requires import requires
                 "xonsh>=0.9.16;python_version > '3.4' and python_version != '3.9'",
             ],
         ),
+        ("pytest>=6.0.0", ["pytest>=6"]),
+        ("pytest==6.0.0", ["pytest==6"]),
+        ("pytest~=6.0.0", ["pytest~=6.0.0"]),
     ],
 )
 def test_requires_fmt(value, result):


### PR DESCRIPTION
... as the complete version number is important.

See PEP 440 for more details
( https://www.python.org/dev/peps/pep-0440/#compatible-release ).

Fixes #24

modified:   src/tox_ini_fmt/formatter/requires.py
modified:   tests/formatter/test_requires.py