### PR TITLE
Fix `tox.ini` formatting when `envlist` ends with a comma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## unreleased
+
+- Fix `tox.ini` formatting when `envlist` ends with a comma
+  ([#41](https://github.com/tox-dev/tox-ini-fmt/issues/41))
+
 ## 0.4.0 (2020-10-04)
 
 - Substitutions for multi-line values go now to the beginning of the configuration (to allow overwriting inherited

--- a/src/tox_ini_fmt/formatter/tox_section.py
+++ b/src/tox_ini_fmt/formatter/tox_section.py
@@ -51,9 +51,11 @@ def to_list_of_env_values(pin_toxenvs: List[str], payload: str) -> str:
             brace_str += char
         else:
             cur_str += char
-    values.append(cur_str.strip())
+    # avoid adding an empty value, caused e.g. by a trailing comma
+    last_entry = cur_str.strip()
+    if last_entry != "":
+        values.append(last_entry)
     # start with higher python version
-
     order_env_list(values, pin_toxenvs)
     # use newline instead of comma as separator, indent values one per newline (no value on key-row)
     result = "\n{}".format("\n".join(f"{v}" for v in values))

--- a/tests/formatter/test_tox_section.py
+++ b/tests/formatter/test_tox_section.py
@@ -80,3 +80,13 @@ def test_tox_fmt_boolean(tox_ini, key, value, result):
 def test_order_env_list(arg, outcome):
     order_env_list(arg, [])
     assert arg == outcome
+
+
+def test_format_tox_ini_handles_trailing_comma(tox_ini):
+    """tox.ini gets formatted without adding additional whitespace
+
+    This was previously caused by a trailing comma in the `envlist`.
+    """
+    tox_ini.write_text("[tox]\nenvlist=\n    py38,\n    pkg,\n" "[testenv:pkg]\na=b\n")
+    result = format_tox_ini(tox_ini)
+    assert result == "[tox]\nenvlist =\n    py38\n    pkg\n\n[testenv:pkg]\na = b\n"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,9 +1,6 @@
-from textwrap import dedent
-
 import pytest
 
 from tox_ini_fmt.__main__ import run
-from tox_ini_fmt.formatter import format_tox_ini
 
 
 @pytest.mark.parametrize("in_place", [True, False])
@@ -43,25 +40,3 @@ def test_main(tmp_path, capsys, in_place, start, outcome, output, monkeypatch, c
         assert out == output
     else:
         assert out == outcome
-
-
-def test_format_tox_ini_handles_trailing_comma(tox_ini):
-    """tox.ini gets formatted without adding additional whitespace
-
-    This was caused by a trailing comma in the `envlist`.
-    """
-    tox_ini.write_text("[tox]\nenvlist=\n    py38,\n    pkg,\n" "[testenv:pkg]\na=b\n")
-    result = format_tox_ini(tox_ini)
-
-    expected = dedent(
-        """
-        [tox]
-        envlist =
-            py38
-            pkg
-
-        [testenv:pkg]
-        a = b
-    """
-    ).lstrip()
-    assert result == expected

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,9 @@
+from textwrap import dedent
+
 import pytest
 
 from tox_ini_fmt.__main__ import run
+from tox_ini_fmt.formatter import format_tox_ini
 
 
 @pytest.mark.parametrize("in_place", [True, False])
@@ -40,3 +43,25 @@ def test_main(tmp_path, capsys, in_place, start, outcome, output, monkeypatch, c
         assert out == output
     else:
         assert out == outcome
+
+
+def test_format_tox_ini_handles_trailing_comma(tox_ini):
+    """tox.ini gets formatted without adding additional whitespace
+
+    This was caused by a trailing comma in the `envlist`.
+    """
+    tox_ini.write_text("[tox]\nenvlist=\n    py38,\n    pkg,\n" "[testenv:pkg]\na=b\n")
+    result = format_tox_ini(tox_ini)
+
+    expected = dedent(
+        """
+        [tox]
+        envlist =
+            py38
+            pkg
+
+        [testenv:pkg]
+        a = b
+    """
+    ).lstrip()
+    assert result == expected


### PR DESCRIPTION
I am here to learn - so if you would do things differently, or when you have any comments, don't be shy.

This fixes #41.

modified:   CHANGELOG.md
modified:   src/tox_ini_fmt/formatter/tox_section.py
modified:   tests/test_main.py