### PR TITLE
Colour the diff output

### DIFF
--- a/src/tox_ini_fmt/__main__.py
+++ b/src/tox_ini_fmt/__main__.py
@@ -1,7 +1,7 @@
 import difflib
 import sys
 from pathlib import Path
-from typing import Optional, Sequence
+from typing import Iterable, Optional, Sequence
 
 from tox_ini_fmt.cli import cli_args
 from tox_ini_fmt.formatter import format_tox_ini
@@ -11,7 +11,7 @@ RED = "\u001b[31m"
 RESET = "\u001b[0m"
 
 
-def color_diff(diff):
+def color_diff(diff: Iterable[str]) -> Iterable[str]:
     for line in diff:
         if line.startswith("+"):
             yield GREEN + line + RESET

--- a/src/tox_ini_fmt/__main__.py
+++ b/src/tox_ini_fmt/__main__.py
@@ -6,6 +6,20 @@ from typing import Optional, Sequence
 from tox_ini_fmt.cli import cli_args
 from tox_ini_fmt.formatter import format_tox_ini
 
+GREEN = "\u001b[32m"
+RED = "\u001b[31m"
+RESET = "\u001b[0m"
+
+
+def color_diff(diff):
+    for line in diff:
+        if line.startswith("+"):
+            yield GREEN + line + RESET
+        elif line.startswith("-"):
+            yield RED + line + RESET
+        else:
+            yield line
+
 
 def run(args: Optional[Sequence[str]] = None) -> int:
     opts = cli_args(sys.argv[1:] if args is None else args)
@@ -26,6 +40,7 @@ def run(args: Optional[Sequence[str]] = None) -> int:
             else []
         )
         if diff:
+            diff = color_diff(diff)
             print("\n".join(diff))  # print diff on change
         else:
             print(f"no change for {name}")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,48 @@
+import difflib
+
 import pytest
 
-from tox_ini_fmt.__main__ import run
+import tox_ini_fmt.__main__
+from tox_ini_fmt.__main__ import GREEN, RED, RESET, color_diff, run
+
+
+def test_color_diff():
+    # Arrange
+    before = """
+    abc
+    def
+    ghi
+"""
+    after = """
+    abc
+    abc
+    def
+"""
+    diff = difflib.unified_diff(before.splitlines(), after.splitlines())
+    expected_lines = f"""
+{RED}---
+{RESET}
+{GREEN}+++
+{RESET}
+@@ -1,4 +1,4 @@
+
+
+     abc
+{GREEN}+    abc{RESET}
+     def
+{RED}-    ghi{RESET}
+""".strip().splitlines()
+
+    # Act
+    diff = color_diff(diff)
+
+    # Assert
+    output_lines = [line.rstrip() for line in "\n".join(diff).splitlines()]
+    assert output_lines == expected_lines
+
+
+def no_color(diff):
+    return diff
 
 
 @pytest.mark.parametrize("in_place", [True, False])
@@ -18,6 +60,7 @@ from tox_ini_fmt.__main__ import run
     ],
 )
 def test_main(tmp_path, capsys, in_place, start, outcome, output, monkeypatch, cwd):
+    monkeypatch.setattr(tox_ini_fmt.__main__, "color_diff", no_color)
     if cwd:
         monkeypatch.chdir(tmp_path)
     tox_ini = tmp_path / "tox.ini"


### PR DESCRIPTION
The diff is a bit hard to read in monochrome.

This PR colours the diff output, based on https://chezsoi.org/lucas/blog/colored-diff-output-with-python.html but defining our own (three) constants instead of using [Colorama](https://github.com/tartley/colorama/), and also skipping `^` as I can't remember seeing it and can't find any [documentation](https://www.gnu.org/software/diffutils/manual/html_node/Detailed-Unified.html#Detailed-Unified) for it.

| Before | After |
| ------ | ----- |
| ![image](https://user-images.githubusercontent.com/1324225/95180705-05ae5a00-07cb-11eb-9711-80266c496c74.png) | ![image](https://user-images.githubusercontent.com/1324225/95180770-178ffd00-07cb-11eb-99e6-c3001a410919.png) |

