### PR TITLE
Declare support for Python 3.9

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,7 +22,7 @@ jobs:
         os:
           - Ubuntu
         py:
-          - 3.9-dev
+          - 3.9
           - 3.8
           - 3.7
           - 3.6
@@ -102,7 +102,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: build package
         run: python -m pep517.build -s -b . -o dist
-      - name: publish to PyPi
+      - name: publish to PyPI
         uses: pypa/gh-action-pypi-publish@master
         with:
           skip_existing: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,11 +24,11 @@ repos:
         args: [--safe]
         language_version: python3.8
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.11.0
+    rev: v1.14.0
     hooks:
       - id: setup-cfg-fmt
   - repo: https://github.com/tox-dev/tox-ini-fmt
-    rev: "0.4.0"
+    rev: "0.5.0"
     hooks:
     - id: tox-ini-fmt
   - repo: https://github.com/PyCQA/flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ long_description_content_type = text/markdown
 url = https://github.com/tox-dev/tox-ini-fmt
 author = Bernat Gabor
 maintainer = Bernat Gabor
+maintainer_email = gaborjbernat@gmail.com
 license = MIT
 license_file = LICENSE.txt
 platforms = any
@@ -19,11 +20,11 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Utilities
 keywords = tox, formatter
-maintainer-email = gaborjbernat@gmail.com
 project_urls =
     Source=https://github.com/tox-dev/tox-ini-fmt
     Tracker=https://github.com/tox-dev/tox-ini-fmt/issues


### PR DESCRIPTION
Required an update to `setup-cfg-fmt` to add the Trove classifier.

We can also test on `3.9` instead of `3.9-dev` on the CI (and fix a typo).