### PR TITLE
Support processing multiple tox ini files at once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 - Fix `tox.ini` formatting when `envlist` ends with a comma
   ([#41](https://github.com/tox-dev/tox-ini-fmt/issues/41))
+- Support processing multiple `tox.ini` files at once ([#119](https://github.com/tox-dev/tox-ini-fmt/pull/119))
 
 ## 0.4.0 (2020-10-04)
 

--- a/src/tox_ini_fmt/cli.py
+++ b/src/tox_ini_fmt/cli.py
@@ -9,7 +9,7 @@ from typing import Any, Sequence
 class ToxIniFmtNamespace(Namespace):
     """Options for tox-ini-fmt tool"""
 
-    tox_ini: Path
+    tox_ini: list[Path]
     stdout: bool
     pin_toxenvs: list[str]
 
@@ -65,5 +65,5 @@ def cli_args(args: Sequence[str]) -> ToxIniFmtNamespace:
         default=[],
         help="tox environments that pin to the start of the envlist (comma separated)",
     )
-    parser.add_argument("tox_ini", type=tox_ini_path_creator, help="tox ini file to format")
+    parser.add_argument("tox_ini", nargs="+", type=tox_ini_path_creator, help="tox ini files to format")
     return parser.parse_args(namespace=ToxIniFmtNamespace(), args=args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,7 +12,17 @@ def test_cli_tox_ini_ok(tmp_path):
     path = tmp_path / "tox.ini"
     path.write_text("")
     result = cli_args([str(path)])
-    assert result.tox_ini == path
+    assert result.tox_ini[0] == path
+
+
+def test_cli_multiple_tox_ini_files_ok(tmp_path):
+    path = tmp_path / "tox.ini"
+    path.write_text("")
+    path_2 = tmp_path / "tox2.ini"
+    path_2.write_text("")
+    result = cli_args([str(path), str(path_2)])
+    assert result.tox_ini[0] == path
+    assert result.tox_ini[1] == path_2
 
 
 def test_cli_tox_ini_not_exists(tmp_path, capsys):
@@ -61,4 +71,4 @@ def test_tox_ini_resolved(tmp_path, monkeypatch):
     path = tmp_path / "tox.ini"
     path.write_text("")
     result = cli_args(["tox.ini"])
-    assert result.tox_ini == path
+    assert result.tox_ini[0] == path


### PR DESCRIPTION
This PR adds support for processing multiple files at once, especially useful when invoked as a pre-commit hook in a repository with multiple tox.ini files in sub-directories.

There are known workarounds for use with pre-commit but its author recommends fixing the tool: https://github.com/pre-commit/pre-commit/issues/1728#issuecomment-741907110