### PR TITLE
Exclude bots from generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,5 @@
+changelog:
+  exclude:
+    authors:
+      - dependabot
+      - pre-commit-ci


### PR DESCRIPTION
Thanks for the new https://github.com/tox-dev/tox-ini-fmt/releases/tag/0.6.0 release!

The generated release notes at https://github.com/tox-dev/tox-ini-fmt/releases/tag/0.6.0 are quite hard to read, they're nearly all dependency updates, for things that don't affect end user changes, making it hard to find the real end-user changes.

![image](https://user-images.githubusercontent.com/1324225/210836748-73b1913c-cdea-4eef-8407-b808e83644a5.png)

The good news is GitHub allows us to easily filter those out via `changelog.exclude.authors` in a config file:

https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuration-options

Let's use automation to improve the automation :) :robot: :rocket:

