### PR TITLE
Test locally against Python 3.11

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
     fix
+    py311
     py310
     py39
     py38


### PR DESCRIPTION
Python 3.11 is tested in CI already but is not tested by default on local Tox runs.