### PR TITLE
Do not mangle a URL dependency as a factor-conditional

### DIFF
--- a/src/tox_ini_fmt/formatter/util.py
+++ b/src/tox_ini_fmt/formatter/util.py
@@ -163,7 +163,9 @@ def order_env_list(values: list[str], pin_toxenvs: list[str]) -> None:
     values.sort(key=partial(_get_py_version, pin_toxenvs), reverse=True)
 
 
-CONDITIONAL_MARKER = re.compile(r"(?P<envs>[a-zA-Z0-9, ]+):(?P<value>.*)")
+# A factor-conditional prefix such as ``py311: pytest``. The ``(?!//)`` guard keeps a URL scheme
+# (``https://...``) from being mistaken for a factor marker, which would split it into ``https: //...``.
+CONDITIONAL_MARKER = re.compile(r"(?P<envs>[a-zA-Z0-9, ]+):(?!//)(?P<value>.*)")
 
 
 def collect_multi_line(

--- a/tests/formatter/test_test_env.py
+++ b/tests/formatter/test_test_env.py
@@ -170,6 +170,14 @@ def test_deps_conditional() -> None:
     )
 
 
+def test_deps_url_not_split_as_conditional() -> None:
+    # A URL scheme must not be mistaken for a factor-conditional marker (``https://`` -> ``https: //``).
+    result = to_py_dependencies(
+        "\nhttps://releases.wagtail.org/nightly/dist/latest.whl\ngit+https://github.com/x/y.git\npytest>=7",
+    )
+    assert result == "\ngit+https://github.com/x/y.git\nhttps://releases.wagtail.org/nightly/dist/latest.whl\npytest>=7"
+
+
 def test_python_req_sort_by_name() -> None:
     result = to_py_dependencies("pytest-cov\npytest\npytest-magic>=1\npytest>=1")
     assert result == "\npytest\npytest>=1\npytest-cov\npytest-magic>=1"


### PR DESCRIPTION
Fixes #352.

### Problem

`tox-ini-fmt` mangles a URL dependency, breaking the `tox.ini`:

```ini
[testenv]
deps =
  https://releases.wagtail.org/nightly/dist/latest.whl
```

is reformatted to `https: //releases.wagtail.org/...` — the injected space breaks the link and tox fails.

### Cause

`CONDITIONAL_MARKER` (`(?P<envs>[a-zA-Z0-9, ]+):(?P<value>.*)`) recognises factor-conditional deps like `py311: pytest`. A URL scheme (`https`) is all alphanumerics followed by `:`, so `https://...` matches with `envs="https"`, `value="//..."`, and is re-emitted as `f"{k}: {d}"` → `https: //...`.

### Fix

Add a `(?!//)` negative lookahead after the colon, so a `scheme://` URL is never treated as a factor marker. A real factor-conditional never has `//` immediately after its colon, so behaviour for conditionals is unchanged. (`git+https://` was already safe — the `+` isn't in the `envs` character class.)

Added `test_deps_url_not_split_as_conditional`; the full suite (95 passed, 1 skipped) and `ruff check`/`ruff format --check` stay green.
