### PR TITLE
Read and write tox.ini as UTF-8

### DIFF
--- a/src/tox_ini_fmt/__main__.py
+++ b/src/tox_ini_fmt/__main__.py
@@ -43,7 +43,7 @@ def run(args: Sequence[str] | None = None) -> int:
     opts = cli_args(sys.argv[1:] if args is None else args)
     changed = False
     for tox_ini in opts.tox_ini:
-        with tox_ini.open("rt") as file:
+        with tox_ini.open("rt", encoding="utf-8") as file:
             before = file.read()
             original_newlines = file.newlines
         if isinstance(original_newlines, tuple):
@@ -54,7 +54,7 @@ def run(args: Sequence[str] | None = None) -> int:
             print(formatted, end="")  # ruff:ignore[print]
         else:
             if before != formatted:
-                with tox_ini.open("wt", newline=original_newlines) as file:
+                with tox_ini.open("wt", encoding="utf-8", newline=original_newlines) as file:
                     file.write(formatted)
             try:
                 name = str(tox_ini.relative_to(Path.cwd()))

--- a/src/tox_ini_fmt/formatter/__init__.py
+++ b/src/tox_ini_fmt/formatter/__init__.py
@@ -26,7 +26,7 @@ def format_tox_ini(tox_ini: str | Path, opts: ToxIniFmtNamespace | None = None) 
     if opts is None:
         opts = ToxIniFmtNamespace(pin_toxenvs=[])
     parser = ConfigParser(interpolation=None)
-    text = tox_ini.read_text() if isinstance(tox_ini, Path) else tox_ini
+    text = tox_ini.read_text(encoding="utf-8") if isinstance(tox_ini, Path) else tox_ini
     parser.read_string(text)
 
     format_tox_section(parser, opts.pin_toxenvs)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import difflib
+import subprocess
+import sys
 from typing import TYPE_CHECKING
 
 import pytest
@@ -117,3 +119,34 @@ def test_main(  # ruff:ignore[too-many-arguments]
         assert out == output
     else:
         assert out == outcome
+
+
+NON_ASCII = "[tox]\nrequires =\n    tox>=4.2\nenv_list =\n    py311\n\n[testenv]\ncommands =\n    pytest -k 丁\n"
+
+
+def test_non_ascii_round_trip(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    tox_ini = tmp_path / "tox.ini"
+    tox_ini.write_text(NON_ASCII, encoding="utf-8")
+
+    assert run([str(tox_ini)]) == 0
+
+    capsys.readouterr()
+    assert tox_ini.read_text(encoding="utf-8") == NON_ASCII
+
+
+def test_non_ascii_ignores_locale_encoding(tmp_path: Path) -> None:
+    # -X warn_default_encoding turns any locale-dependent open() into an EncodingWarning, so this fails on
+    # every platform rather than only where the locale encoding cannot represent the file.
+    tox_ini = tmp_path / "tox.ini"
+    tox_ini.write_text(NON_ASCII, encoding="utf-8")
+
+    subprocess.check_call([
+        sys.executable,
+        "-X",
+        "warn_default_encoding",
+        "-W",
+        "error::EncodingWarning",
+        "-m",
+        "tox_ini_fmt",
+        str(tox_ini),
+    ])


### PR DESCRIPTION
`tox-ini-fmt` currently reads `tox.ini` using the locale encoding, which can cause a `UnicodeDecodeError` for valid UTF-8 files on Windows.

This updates the file reads/writes to use UTF-8 and adds regression tests for non-ASCII content and default-encoding warnings.

Full test suite passes (97 passed, 1 skipped); ruff and mypy are clean.
